### PR TITLE
install zsh in RHEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Try this one of these:
 | Arch Linux | `pacman -S util-linux` |
 | Kali Linux | `apt-get install passwd` |
 | CentOS | `yum install util-linux-ng` |
+| RHEL | `dnf install -y sudo zsh cracklib-dicts` |
 | Fedora | `dnf install util-linux-user` |
 | macOS | `brew install util-linux` |
 | Raspbian | `apt-get install passwd` |


### PR DESCRIPTION
Added correct package names for `zsh` in RHEL version 8 and above. 

[Reference: Setup zsh  ](https://medium.com/@AnupamMajhi/linux-zsh-theme-i-use-dd6921cd6084)